### PR TITLE
공지사항,일기쓰기 페이지-지윤

### DIFF
--- a/src/main/java/com/example/redmedicine/domain/dto/DiaryDto.java
+++ b/src/main/java/com/example/redmedicine/domain/dto/DiaryDto.java
@@ -19,7 +19,7 @@ public class DiaryDto {
         private Long diaryNumber;
         private Long userNumber;
         private String diaryTitle;
-        private String diaryDate;
+        private Date diaryDate;
         private String diaryContent;
         private String diaryOpen;
 }

--- a/src/main/java/com/example/redmedicine/domain/dto/NoticeDto.java
+++ b/src/main/java/com/example/redmedicine/domain/dto/NoticeDto.java
@@ -18,6 +18,6 @@ public class NoticeDto {
     private Long noticeNumber;
     private Long userNumber;
     private String noticeTitle;
-    private String noticeDate;
+    private Date noticeDate;
     private String noticeContent;
 }

--- a/src/main/java/com/example/redmedicine/domain/vo/DiaryVo.java
+++ b/src/main/java/com/example/redmedicine/domain/vo/DiaryVo.java
@@ -13,7 +13,7 @@ public class DiaryVo {
     private Long diaryNumber;
     private Long userNumber;
     private String diaryTitle;
-    private String diaryDate;
+    private Date diaryDate;
     private String diaryContent;
     private String diaryOpen;
     private String userId;

--- a/src/main/java/com/example/redmedicine/domain/vo/NoticeVo.java
+++ b/src/main/java/com/example/redmedicine/domain/vo/NoticeVo.java
@@ -13,7 +13,7 @@ public class NoticeVo {
     private Long noticeNumber;
     private Long userNumber;
     private String noticeTitle;
-    private String noticeDate;
+    private Date noticeDate;
     private String noticeContent;
     private String userId;
     private String userName;

--- a/src/main/resources/templates/board/diary.html
+++ b/src/main/resources/templates/board/diary.html
@@ -42,24 +42,25 @@
                             <tbody>
                                 <tr th:each="diary, i : ${diaryList}">
                                     <td th:text="${i.index+1}">1</td>
-                                    <td th:if="${diary.diaryOpen == 1 && diary.userNumber == session.userNumber}">
-                                        <a th:href="@{/diary/detail(diaryNumber=${diary.diaryNumber})}">
+
+                                    <td>
+                                        <a th:if="${diary.diaryOpen == '0'}" th:href="@{/diary/detail(diaryNumber=${diary.diaryNumber})}">
                                             <span th:text="${diary.diaryTitle}">제목</span>
                                         </a>
-                                    </td>
-                                    <td th:unless="${diary.diaryOpen == 1 && diary.userNumber != session.userNumber}">
-<!--                                        <a th:href="@{/diary/detail(diaryNumber=${diary.diaryNumber})}">-->
+                                        <span th:unless="${diary.diaryOpen == '0'}">
+                                            <a th:if="${diary.userNumber == session.userNumber}" th:href="@{/diary/detail(diaryNumber=${diary.diaryNumber})}">
                                             <span th:text="${diary.diaryTitle}">제목</span>
-<!--                                        </a>-->
+                                            </a>
+                                            <span th:unless="${diary.userNumber == session.userNumber}">비공개 글 입니다.</span>
+                                        </span>
                                     </td>
-                                    <td th:unless="${diary.diaryOpen == 0}">
-                                        <a th:href="@{/diary/detail(diaryNumber=${diary.diaryNumber})}">
-                                            <span th:text="${diary.diaryTitle}">제목</span>
-                                        </a>
-                                    </td>
+
                                     <td th:text="${diary.userName}">이지윤</td>
-                                    <td th:text="${diary.diaryDate}">2023-09-09</td>
-                                    <td th:text="${diary.diaryOpen}">공개</td>
+                                    <td th:text="${#dates.format(diary.diaryDate,'yyyy-MM-dd')}">2023-09-09</td>
+                                    <td>
+                                        <span th:if="${diary.diaryOpen == '0'}" >공개</span>
+                                        <span th:unless="${diary.diaryOpen == '0'}">비공개</span>
+                                    </td>
                                 </tr>
                             </tbody>
                         </table>

--- a/src/main/resources/templates/board/notice.html
+++ b/src/main/resources/templates/board/notice.html
@@ -48,7 +48,7 @@
                                         </a>
                                     </td>
                                     <td>관리자</td>
-                                    <td th:text="${notice.noticeDate}"></td>
+                                    <td th:text="${#dates.format(notice.noticeDate,'yyyy-MM-dd')}"></td>
                                 </tr>
                             </tbody>
                         </table>

--- a/src/main/resources/templates/board/readingDiary.html
+++ b/src/main/resources/templates/board/readingDiary.html
@@ -27,7 +27,7 @@
                     <div class="title" th:text="${diary.diaryTitle}">오늘의 일기</div>
                     <div class="writer-date">
                         <div class="writer" th:text="${diary.userName}">이지윤</div>
-                        <div class="date" th:text="${diary.diaryDate}">2023-09-14</div>
+                        <div class="date" th:text="${#dates.format(diary.diaryDate,'yyyy-MM-dd HH:mm')}">2023-09-14</div>
                     </div>
                     <div class="content">
                         <div class="content-text" th:text="${diary.diaryContent}"></div>

--- a/src/main/resources/templates/board/readingNotice.html
+++ b/src/main/resources/templates/board/readingNotice.html
@@ -27,7 +27,7 @@
                     <div class="title" th:text="${notice.noticeTitle}">공지사항 입니다.</div>
                     <div class="writer-date">
                         <div class="writer" th:text="${notice.userName}">관리자</div>
-                        <div class="date" th:text="${notice.noticeDate}">2023-09-14</div>
+                        <div class="date" th:text="${#dates.format(notice.noticeDate,'yyyy-MM-dd HH:mm')}">2023-09-14</div>
                     </div>
                     <div class="content">
                         <div class="content-text" th:text="${notice.noticeContent}"></div>


### PR DESCRIPTION
-공지사항 날짜 형식 변경 : 타임리프 이용, NoticeDto와 NoticeVo의 noticeDate필드의 자료형을 Date로 변경
 -일기쓰기 날짜 형식 변경 : 위와 동일
-일기쓰기 공개/비공개 설정
 :공개 글일 경우 모든 사람이 열람 가능
 :비공개 글일 경우 작성자 본인만 열람 가능
 :비공개 글일 경우 작성자 본인 아닐 경우 글 목록에서 글 제목이 "비공개 글 입니다"로 표시
 :글 목록에서 공개여부 0,1로 표시됐던것 -> 공개/비공개로 변경되어 표시
-공지사항,일기쓰기 글읽기 페이지 날짜형식 수정